### PR TITLE
feat: rejoint traefik-public, labels de routage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,13 +7,27 @@ services:
       - NUXT_PUBLIC_API_BASE=https://milestone.unionrolistes.fr
     image: app
     container_name: app
+    # Port encore publié pendant la préparation de la bascule Traefik :
+    # Apache en dépend tant que la bascule finale n'a pas eu lieu. Retiré
+    # une fois Apache arrêté (Traefik devient l'unique point d'entrée).
     ports:
       - "3000:3000"
     restart: always
     networks:
       - default
+      - traefik-public
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.milestone.rule=Host(`milestone.unionrolistes.fr`)"
+      - "traefik.http.routers.milestone.entrypoints=websecure"
+      - "traefik.http.routers.milestone.tls.certresolver=le"
+      - "traefik.http.services.milestone.loadbalancer.server.port=3000"
     volumes:
       - ./prisma/milestone.db:/app/.output/server/prisma/milestone.db
+
+networks:
+  traefik-public:
+    external: true
 
 
 


### PR DESCRIPTION
Prépare la bascule Traefik (remplace Apache comme ingress unique pour les domaines *.unionrolistes.fr). Découverte par labels Docker plutôt qu'un vhost Apache séparé à maintenir.

Le port publié (3000) reste en place tant qu'Apache en a besoin — retiré dans une PR de suivi une fois la bascule finale (Apache arrêté) confirmée.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>