### PR TITLE
perf: Dockerfile multi-stage (750MB -> 272MB)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,5 @@ node_modules
 npm-debug.log
 .nuxt
 .git
+.output
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,36 @@
-FROM node:22-bookworm-slim
+# Multi-stage : le stage builder installe toutes les dépendances (y compris
+# devDependencies : nuxt, prisma CLI, types) pour générer .output/, un
+# bundle Nitro autonome qui embarque déjà ses propres node_modules tracés.
+# Le stage final ne copie que .output/ — plus besoin du toolchain de build
+# ni des devDependencies (~440MB de npm install jetés une fois le build
+# terminé).
+FROM node:22-bookworm-slim AS build
 
-# Create app directory
-RUN mkdir -p /app
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends openssl && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
-#Install app dependencies
-RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends openssl && rm -rf /var/lib/apt/lists/*
-    
-#Set environment variables
-
-
-# Bundle app source
 COPY . /app
 RUN npm install
 
-
-
-
-#congig prisma
 RUN npx prisma generate
 RUN npx prisma migrate deploy
 RUN npx prisma migrate status
 
-# Build app
 RUN npm run build
 
-#Set prisma folder
-RUN mkdir  /app/.output/server/prisma
-RUN cp /app/prisma/milestone.db /app/.output/server/prisma/milestone.db
+RUN mkdir /app/.output/server/prisma && cp /app/prisma/milestone.db /app/.output/server/prisma/milestone.db
+
+
+FROM node:22-bookworm-slim
+
+# openssl requis par le moteur Prisma au runtime (mêmes bibliothèques que
+# lors du `prisma generate` du stage builder, binaryTargets="native").
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends openssl && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=build /app/.output /app/.output
 
 ENV NUXT_HOST=0.0.0.0
 ENV NUXT_PORT=3000
@@ -35,5 +38,6 @@ ENV NUXT_PORT=3000
 # Expose port
 EXPOSE 3000 5555
 
-#start app
-CMD [ "npm", "run", "start" ]
+# Appel direct du serveur Nitro déjà construit — pas besoin du CLI nuxt
+# (devDependency, absente de ce stage) pour lancer `npm run start`.
+CMD ["node", ".output/server/index.mjs"]


### PR DESCRIPTION
## Résumé
- L'image finale gardait tout le `npm install` (devDependencies incluses : nuxt, prisma CLI, types) alors que `.output/` (bundle Nitro généré par `nuxt build`) est autonome et trace déjà ses propres dépendances runtime.
- Passage en multi-stage : le stage `build` installe/génère/build comme avant, le stage final ne copie que `.output/` et lance `node .output/server/index.mjs` directement (plus besoin du CLI nuxt pour `npm run start`, absent du stage final).
- `.env` et `.output` ajoutés à `.dockerignore` (`.env` n'était pas exclu du contexte de build jusqu'ici).

## Risque identifié et vérifié
Nitro trace les dépendances utilisées par le serveur, mais Prisma (moteur natif) et bcrypt (binding natif) sont des cas connus où cette détection automatique peut échouer. Vérifié explicitement avant d'ouvrir cette PR plutôt que de supposer que ça marche :
- `.output/server/node_modules/.prisma` et `@prisma` présents, avec le moteur natif `libquery_engine-debian-openssl-3.0.x.so.node`
- binding natif `bcrypt` présent
- conteneur démarré réellement sur le VPS : `GET /api/task` (route non authentifiée qui fait une vraie requête Prisma) répond `200 {"tasks":[]}`, `GET /` répond `200`

## Mesures
Taille de l'image : 750MB -> 272MB (-64%)

## Test plan
- [x] Build multi-stage réussi (`--no-cache`)
- [x] Présence vérifiée des binaires natifs Prisma/bcrypt dans l'image finale
- [x] Conteneur démarré, requête Prisma réelle testée en direct (`/api/task`)
- [ ] Redéploiement en prod (pas fait dans cette PR — à planifier séparément)

Closes #159