### PR TITLE
chore: retire le port legacy 3000 (Traefik est l'unique point d'entrée)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,11 +7,6 @@ services:
       - NUXT_PUBLIC_API_BASE=https://milestone.unionrolistes.fr
     image: app
     container_name: app
-    # Port encore publié pendant la préparation de la bascule Traefik :
-    # Apache en dépend tant que la bascule finale n'a pas eu lieu. Retiré
-    # une fois Apache arrêté (Traefik devient l'unique point d'entrée).
-    ports:
-      - "3000:3000"
     restart: always
     networks:
       - default


### PR DESCRIPTION
Closes #160

Le port était laissé intentionnellement publié pendant la préparation de la bascule Traefik (Apache en dépendait). Apache est maintenant entièrement retiré, Traefik gère tout le routage via labels — ce port n'est plus utile et n'était accessible que par contournement du firewall (bloqué depuis le 2026-07-15 par la chaîne DOCKER-USER).