### PR TITLE
fix: retire la ligne image: redondante (bloquait le déploiement Komodo)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
       - .env
     environment:
       - NUXT_PUBLIC_API_BASE=https://milestone.unionrolistes.fr
-    image: app
     container_name: app
     restart: always
     networks:


### PR DESCRIPTION
Closes #162

`docker compose pull` (lancé par Komodo avant le build) tentait de récupérer `app` depuis un registre au lieu de la construire localement — échec `pull access denied`. Retire la ligne `image:` redondante.